### PR TITLE
chore(deps): bump CI actions (setup-uv v7, setup-python v6, setup-node v6)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,14 @@ jobs:
             - uses: actions/checkout@v7
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v6
+              uses: astral-sh/setup-uv@v7
               with:
                 version: "0.6.12"
                 enable-cache: true
                 cache-dependency-glob: "uv.lock"
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version-file: ".python-version"
             

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           registry-url: https://registry.npmjs.org/
           node-version: lts/*


### PR DESCRIPTION
Combines three stale Dependabot bumps that conflicted on the workflow files after actions/checkout was bumped to v7 (#18). Supersedes #13 (setup-uv), #10 (setup-python), #12 (setup-node).