### PR TITLE
feat(ch12): expose sut_percentage on BasicFreewaysInput; pin library >=0.2.0

### DIFF
--- a/hcm_mcp_server/core/models.py
+++ b/hcm_mcp_server/core/models.py
@@ -102,6 +102,7 @@ class BasicFreewaysInput(BaseModel):
     speed_limit: int = Field(default=65, description="Posted speed limit in mph")
     phf: float = Field(default=0.95, description="Peak hour factor")
     p_t: float = Field(default=0.05, description="Heavy-vehicle proportion (decimal)")
+    sut_percentage: int = Field(default=0, description="Single-unit-truck share of the heavy-vehicle mix; 0 = unknown (general-terrain Exhibit 12-25), or 30/50/70 for the specific-upgrade exhibits 12-26/27/28")
     demand_flow_i: float = Field(default=1000.0, description="Directional demand in veh/h")
     length: float = Field(default=0.625, description="Segment length in miles")
     highway_type: str = Field(default="basic", description="'basic' or 'multilane'")

--- a/hcm_mcp_server/functions/chapter12.py
+++ b/hcm_mcp_server/functions/chapter12.py
@@ -2,7 +2,7 @@
 
 The freeway counterpart to ``chapter15.py``: each function wraps the verified ``transportations_library.BasicFreeways`` implementation (a *different equation family* than the two-lane methodology) and follows the same ``(data: dict) -> dict`` convention. A basic-freeway analysis is a single directional segment, so the input is ``data["freeway_data"]`` (a flat ``BasicFreewaysInput``), not a multi-segment facility.
 
-The HCM Ch.12 step sequence is stateful, so each step function rebuilds the segment and runs its prerequisites in order before the requested step (mirroring ``chapter15.py``). The library tabulates heavy-vehicle effects only at discrete grade/length grid points and raises a Rust panic off-grid; the ``_guarded`` decorator catches that (a PyO3 PanicException is NOT a Python Exception) and returns a clean error instead of crashing.
+The HCM Ch.12 step sequence is stateful, so each step function rebuilds the segment and runs its prerequisites in order before the requested step (mirroring ``chapter15.py``). Heavy-vehicle equivalence depends on ``sut_percentage``: at the default 0 the library reads the general-terrain exhibit (12-25) and grade/length are irrelevant, while 30/50/70 select the specific-upgrade exhibits (12-26/27/28), which the library interpolates over grades to 6% and rejects (a Python ``ValueError``) for off-domain inputs. The ``_guarded`` decorator turns any such failure into a clean error dict instead of a raised exception.
 """
 
 from functools import wraps
@@ -14,7 +14,7 @@ from hcm_mcp_server.core.models import BasicFreewaysInput
 
 
 def _guarded(step: float | None = None) -> Callable:
-    """Wrap a function so any failure — including a Rust PanicException (off the heavy-vehicle PCE grid), which is not a Python Exception — returns a clean error dict."""
+    """Wrap a function so any failure — a validation ``ValueError`` (e.g. an off-domain specific-upgrade grade) or, defensively, a PyO3 PanicException that is not a Python Exception — returns a clean error dict."""
     def decorator(fn: Callable[[Dict[str, Any]], Dict[str, Any]]) -> Callable:
         @wraps(fn)
         def wrapper(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -46,6 +46,7 @@ def create_freeway_from_input(fw: BasicFreewaysInput) -> BasicFreeways:
         speed_limit=fw.speed_limit,
         phf=fw.phf,
         p_t=fw.p_t,
+        sut_percentage=fw.sut_percentage,
         demand_flow_i=fw.demand_flow_i,
         length=fw.length,
         highway_type=fw.highway_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,9 @@ dependencies = [
     # The reasoning layer (repair/reconcile/inverse/chaining + BasicFreeway), the
     # Chapter 12 tools, and validate_design_full need:
     #   - transportations-validator >=0.2.0 (seed-backed engine + reasoning modules)
-    #   - transportations-library >=0.1.12 (BasicFreeways PyO3 binding)
+    #   - transportations-library >=0.2.0 (BasicFreeways PyO3 binding: sut_percentage kwarg, corrected Ch.12 PCE tables, e_t/f_hv accessors)
     "transportations-validator>=0.2.0",
-    "transportations-library>=0.1.12",
+    "transportations-library>=0.2.0",
 ]
 
 [dependency-groups]

--- a/tests/test_chapter12.py
+++ b/tests/test_chapter12.py
@@ -19,8 +19,14 @@ pytestmark = pytest.mark.skipif(
     reason="transportations-library>=0.1.12 with the BasicFreeways Ch.12 binding required",
 )
 
+# 25% trucks, 2% grade, 3100 veh/h. No SUT mix is given (sut_percentage defaults to 0),
+# so E_T comes from the general-terrain exhibit (12-25, level) = 2.0, not a specific-upgrade
+# table. At 12 ft lanes the segment holds LOS D (FFS 66.78, density 33.9); dropping to 10 ft
+# lanes lowers FFS to 60.18 and pushes density to 36.04 → LOS E. Demand is 3100, not the
+# pre-fix 3000: at 3000 the corrected general-terrain default already yields LOS D at 10 ft,
+# so NARROW would no longer degrade. See tests/unit/test_repair.py for the full hand derivation.
 GOOD = {"bffs": 70.0, "lw": 12.0, "lane_count": 2, "lc_r": 6, "trd": 1,
-        "demand_flow_i": 3000.0, "phf": 0.95, "p_t": 0.25, "grade": 2.0, "length": 0.625}
+        "demand_flow_i": 3100.0, "phf": 0.95, "p_t": 0.25, "grade": 2.0, "length": 0.625}
 NARROW = {**GOOD, "lw": 10.0}
 
 
@@ -51,10 +57,15 @@ class TestSteps:
         assert C.estimate_density_function(d)["density"] > 0
         assert C.determine_segment_los_function(d)["level_of_service"] == "E"
 
-    def test_off_grid_inputs_return_clean_error(self):
+    def test_off_domain_specific_upgrade_returns_clean_error(self):
+        """The specific-upgrade exhibits (12-26/27/28) are tabulated only to a 6%
+        grade; a steeper grade with an explicit SUT mix is off-domain and the
+        library raises, which _guarded turns into a clean error dict. At the
+        default sut_percentage=0 grade is irrelevant (general terrain), so the
+        error path is only reachable with a specific-upgrade mix."""
         from hcm_mcp_server.functions.chapter12 import complete_freeway_analysis_function
         out = complete_freeway_analysis_function(
-            {"freeway_data": {**NARROW, "grade": 3.7, "length": 0.5}}
+            {"freeway_data": {**NARROW, "sut_percentage": 30, "grade": 7.0}}
         )
         assert out["success"] is False
         assert "error" in out


### PR DESCRIPTION
**Stacked on #21** (base is `feat/mcp-reasoning-foundation`, not `dev`, so this diff shows only the ch12 wiring). Retarget to `dev` once #21 merges.

Downstream of the `transportations_library` 0.2.0 Chapter 12 fix (`sut_percentage` default flipped 50 → 0):

- Add `sut_percentage` to `BasicFreewaysInput` and pass it through `create_freeway_from_input`, so the specific-upgrade PCE exhibits (12-26/27/28) are reachable again. With the new default of 0 the MCP arm could no longer reach them at all.
- Re-derive the ch12 fixtures (demand 3000 → 3100) so `NARROW` still degrades to LOS E under the corrected general-terrain default; `GOOD` holds LOS D (density 33.9). Hand derivation in the sibling validator PR.
- Re-point the error-path test to an off-domain specific-upgrade grade (`sut_percentage=30, grade=7%` > 6% max), since at the default `sut=0` grade is inert.
- Pin `transportations-library >=0.2.0` and refresh docstrings describing the removed Rust panic.

Greenlit earlier by adversarial code-review + PI concept-alignment (both MERGE). `tests/test_chapter12.py` — 4 passed against library 0.2.0.