### PR TITLE
CI: run pytest, not only ruff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,31 @@ jobs:
             - name: Lint with Ruff
               run: uv run ruff check .
               continue-on-error: true
+    pytest:
+        name: Pytest
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                version: "0.6.12"
+                enable-cache: true
+                cache-dependency-glob: "uv.lock"
+
+            - name: Set up Python
+              uses: actions/setup-python@v7
+              with:
+                python-version-file: ".python-version"
+
+            - name: Install dependencies
+              # Same --no-sources reasoning as the Ruff job: resolve the pinned
+              # transportations-library from the index, not the sibling path.
+              run: uv sync --all-extras --dev --no-sources
+
+            - name: Run the test suite
+              # No continue-on-error. A red suite is the signal this job exists
+              # for: a stale expected value sat failing on main unnoticed until
+              # 2026-08-18 because nothing ran pytest here.
+              run: uv run pytest -q

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
               run: uv sync --all-extras --dev --no-sources
 
             - name: Lint with Ruff
-              run: uv run ruff check .
+              run: uv run --no-sources ruff check .
               continue-on-error: true
     pytest:
         name: Pytest
@@ -62,4 +62,4 @@ jobs:
               # No continue-on-error. A red suite is the signal this job exists
               # for: a stale expected value sat failing on main unnoticed until
               # 2026-08-18 because nothing ran pytest here.
-              run: uv run pytest -q
+              run: uv run --no-sources pytest -q


### PR DESCRIPTION
The MCP coverage work found a stale expected value failing live on main, unnoticed because CI runs only ruff (and with continue-on-error). This adds a pytest job mirroring the ruff job's uv setup — same --no-sources resolution of the pinned transportations-library from the index — without continue-on-error, since a red suite is the signal the job exists for.

Note on sequencing: on current main this job will be green only after PR #28 lands (the stale Ch34 pin fix rides there); merging this first would show the exact red that motivated it, which is arguably the point. Either order works.