### PR TITLE
Declare simpleeval, and make a failed tool import loud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Fixed: `validation_validate_design_full` was a stub in every clean install
+
+`transportations_validator.validators.engine` imports `simpleeval` unconditionally, but `transportations-validator` declares it only under its `api` and `all` extras, never in its base requirements. This project did not declare it either, so it was present only in developer venvs that had picked it up by accident. In any clean install — CI, a fresh deployment, anyone following the README — `hcm_mcp_server.functions.validation` failed to import and the tool answered every call with `{"success": false, "error": "Function validate_design_full_function not found"}`.
+
+`simpleeval>=1.0.0` (resolving to 1.0.7) is now a declared runtime dependency. Taking `transportations-validator[api]` instead would have pulled fastapi, asyncpg, neo4j, uvicorn and the plotting stack into a deployment that runs the engine in-process with no database, so the one package actually needed is declared directly. It can be dropped once the validator lists it among its base requirements.
+
+Three things had to line up for this to ship unnoticed, and all three are now covered:
+
+- `FunctionRegistry.register_function` degrades a failed module import to a lambda placeholder. The tool keeps its name, description and schema, the server starts clean, and nothing raises. `TestEveryRegisteredToolImported` now asserts no registered tool resolves to that placeholder and that every module named in the registry imports, reporting the real exception rather than a swallowed warning. The degradation behaviour itself is unchanged: the server's runtime semantics under a partial install are part of what the ablation measured, so the guard is a test, not a behaviour change.
+- `tests/test_validation_full.py` guards its import with `pytest.importorskip`, so when the import broke, the one suite that exercised this tool skipped instead of failing. A test that runs the full-corpus validator end to end and does not skip now sits beside the import guard.
+- The frozen-surface guard caught it only incidentally, through the placeholder's `<lambda>` function name, and its failure message read "this is a revert, not a snapshot update" — which sent the first investigation looking for an edit that had never happened. That message now names the placeholder case explicitly and points at the import check.
+
+The snapshot in `tests/data/paper_surface.json` is unchanged and was never wrong. The published tool surface did not change; one of its ten tools was broken by a missing dependency, which is exactly what the guard exists to notice.
+
 ## 0.3.0
 
 ### The paper surface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,20 @@ dependencies = [
     # validate_design_full runs the full rule engine in-process via the ORM
     # model classes — sqlalchemy the library, but no database server / asyncpg.
     "sqlalchemy>=2.0.0",
+    # simpleeval is what the validator's rule engine evaluates formula-type rule
+    # expressions with. transportations-validator imports it unconditionally from
+    # validators/engine.py but declares it only under its `api` and `all` extras,
+    # so a base install of the validator cannot import the engine at all. We take
+    # those extras deliberately (they pull fastapi, asyncpg, neo4j, uvicorn and
+    # the plotting stack, which an in-process no-database deployment has no use
+    # for), so the one genuinely needed package is declared here instead.
+    #
+    # This is compensating for an upstream metadata gap, not a dependency this
+    # repo chose: drop it once transportations-validator lists simpleeval among
+    # its base requirements. Until 2026-08-19 it was undeclared on both sides and
+    # only present in developer venvs by accident, which left
+    # validation_validate_design_full a non-functional stub in any clean install.
+    "simpleeval>=1.0.0",
     # The reasoning layer (repair/reconcile/inverse/chaining + BasicFreeway), the
     # Chapter 12 tools, and validate_design_full need:
     #   - transportations-validator >=0.3.0 (seed-backed engine + reasoning modules + coverage/abstention on semantic results)

--- a/tests/test_frozen_surface.py
+++ b/tests/test_frozen_surface.py
@@ -48,8 +48,12 @@ class TestPublicSurfaceIsFrozen:
         live = live_surface(include_legacy=False)
         for name, frozen in SNAPSHOT["public"].items():
             assert live[name] == frozen, (
-                f"the published tool {name!r} changed. Diff against tests/data/paper_surface.json. "
-                "Name, JSON schema and description are all part of what the ablation measured, so this is a revert, not a snapshot update."
+                f"the published tool {name!r} changed. Diff against tests/data/paper_surface.json.\n"
+                "If the differing field is 'function' and the live value is '<lambda>', this is NOT an edit to the tool: "
+                "the registry degraded a failed module import to a placeholder. Look for a 'Could not import module' "
+                "line in the captured stdout and fix the missing dependency; see TestEveryRegisteredToolImported below.\n"
+                "Otherwise: name, JSON schema and description are all part of what the ablation measured, so this is a "
+                "revert, not a snapshot update."
             )
 
     def test_new_tools_are_additive_only(self):
@@ -62,6 +66,63 @@ class TestPublicSurfaceIsFrozen:
         # exact set keeps a later change from quietly reintroducing a
         # method-per-tool surface and tripling every caller's context cost.
         assert added == {"hcm_analyze", "hcm_describe", "hcm_validate"}, sorted(added)
+
+
+class TestEveryRegisteredToolImported:
+    """No registered tool may be a placeholder.
+
+    ``FunctionRegistry.register_function`` degrades a failed module import into a lambda that answers every call with ``{"success": false, "error": "Function ... not found"}``. Nothing raises, the tool keeps its name, description and schema, and the server starts clean — so a tool can ship completely broken and look healthy.
+
+    That is exactly how ``validation_validate_design_full`` shipped broken: ``simpleeval`` is imported unconditionally by the validator's rule engine but was declared by neither the validator's base requirements nor this project's, so it was present only in developer venvs that had picked it up by accident. Every clean install served a stub. The frozen-surface snapshot caught it by accident, through the placeholder's ``<lambda>`` name, and its message pointed at the wrong cause.
+
+    These tests make the real cause loud. They are deliberately tests rather than a change to the registry's degradation behaviour: the server's runtime semantics are part of what the ablation measured, and a registry that started raising on import failure could change how an arm behaves under a partial install.
+    """
+
+    def test_no_registered_tool_is_an_import_placeholder(self):
+        registry = FunctionRegistry(REGISTRY_FILE, include_legacy=True)
+        broken = {
+            name: info["module"]
+            for name, info in registry.get_all_functions().items()
+            if info["function"].__name__ == "<lambda>" or info.get("available") is False
+        }
+        assert not broken, (
+            f"these tools resolved to the registry's import placeholder and answer every call with an error: {broken}. "
+            "A missing dependency is the usual cause; the captured stdout carries the 'Could not import module' line "
+            "naming it. Declare it in pyproject rather than relying on it being present by accident."
+        )
+
+    def test_every_module_named_in_the_registry_imports(self):
+        """Checked directly rather than through the registry, so a module that fails to import is reported with its real exception instead of a swallowed warning."""
+        import importlib
+
+        import yaml
+
+        config = yaml.safe_load(REGISTRY_FILE.read_text())
+        modules = {
+            entry["module"]
+            for block in ("functions", "legacy_functions")
+            for section in config.get(block, {}).values()
+            for entry in section.values()
+        }
+        failures = {}
+        for module in sorted(modules):
+            try:
+                importlib.import_module(module)
+            except Exception as e:  # noqa: BLE001 -- the point is to report it
+                failures[module] = f"{type(e).__name__}: {e}"
+        assert not failures, f"registry modules that do not import: {failures}"
+
+    def test_the_full_corpus_validator_actually_runs(self):
+        """The tool whose breakage started this. Its own suite uses ``importorskip``, so when the import broke that suite skipped rather than failed -- the second reason a stub shipped unnoticed. This one does not skip."""
+        import asyncio
+
+        registry = FunctionRegistry(REGISTRY_FILE)
+        impl = registry.get_function("validation_validate_design_full")
+        assert impl is not None
+        result = asyncio.run(impl({"design": {"lane_width": 8.0, "facility_type": "TwoLaneHighway"}}))
+        assert result["success"] is True, result.get("error")
+        assert result["error_count"] >= 1, "a 8 ft lane should violate the Exhibit 15-8 range"
+        assert any(v.get("citation") for v in result["violations"]), "violations must carry citations"
 
 
 class TestLegacySurfaceIsFrozen:

--- a/uv.lock
+++ b/uv.lock
@@ -525,6 +525,7 @@ dependencies = [
     { name = "pymupdf4llm" },
     { name = "python-dotenv" },
     { name = "sentence-transformers" },
+    { name = "simpleeval" },
     { name = "sqlalchemy" },
     { name = "supabase" },
     { name = "transportations-library" },
@@ -551,6 +552,7 @@ requires-dist = [
     { name = "pymupdf4llm", specifier = ">=0.0.25" },
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "sentence-transformers", specifier = "==5.0.0" },
+    { name = "simpleeval", specifier = ">=1.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "supabase", specifier = "==2.18.0" },
     { name = "transportations-library", editable = "../transportations-library" },
@@ -2101,6 +2103,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "simpleeval"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9d/e7c9309940794dd3073cba2e5101df5874d84243595ce63b1e1c8f9b9c76/simpleeval-1.0.7.tar.gz", hash = "sha256:1e10e5f9fec597814444e20c0892ed15162fa214c8a88f434b5b077cf2fef85b", size = 30250, upload-time = "2026-03-16T10:53:03.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl", hash = "sha256:97ac271bfd8f2af9e7b9a36ceea67617f26fa873f9d5ae1922f64d4c1442534b", size = 18792, upload-time = "2026-03-16T10:53:02.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The pytest CI job's first honest run caught it: `validation_validate_design_full` — one of the ten paper-surface tools — was a non-functional stub in every clean install. `transportations-validator` imports `simpleeval` unconditionally but declares it only under extras, this project didn't declare it either, and three accomplices let it ship silently: the registry degrades a failed import to a lambda placeholder without raising, the one test exercising the tool guarded itself with `importorskip` and skipped, and the frozen-surface guard caught it only incidentally through the placeholder's `__name__` while its message pointed investigators at an edit that never happened.

**Verified where it matters most**: `.venv-ablation` (the published experiment environment) carries simpleeval 1.0.7 and its `validate_design_full_function` is the real function — checked read-only, so the paper's runs used a working validator and no published result is in question. The bug affected clean installs only.

Fix: declare `simpleeval>=1.0.0` directly (taking `transportations-validator[api]` would drag a database/plotting stack into an explicitly in-process deployment; comment says to drop this once upstream declares it in base). Three new non-skipping tests make the failure class unshippable: no registered tool may resolve to the placeholder, every registry-named module must import (reporting the real exception), and the full-corpus validator must actually run. The guard's misleading message is fixed. Registry degradation behavior is deliberately unchanged — the runtime semantics under partial install are part of what the ablation measured, so the guard is a test, not a behavior change. `paper_surface.json` is untouched and was never wrong.

Verification both ways: 166 passed / 0 skipped in a CI-equivalent index-resolved env AND against the sibling; removing/restoring simpleeval flips 166 → 4 failed → 166. Control-verified with the honest caveat in the branch report that the CI-equivalent env shared heavy ML wheels with an existing venv for network reasons, with the three decision-relevant packages proven by behavior (including a provenance check that caught a stale .so masquerading as 0.3.6).

Merge order: this, then PR #29 (rebased) goes green and the repo has a real test gate.