### PR TITLE
Add the Chapter 15 bicycle mode as hcm_analyze's 33rd method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
-## Unreleased
+## 0.3.1
+
+### Added: the Chapter 15 bicycle mode, `analyze_bicycle_los`
+
+`hcm_analyze`'s thirty-third method, closing the one gap 0.3.0 shipped with. The HCM Chapter 15 Section 4 bicycle mode has been in the compute library's Rust core since the chapter went in, but it had no PyO3 binding, so it could not be offered here. `transportations-library` 0.3.7 exports it as `analyze_bicycle_los` and a `BicycleLOS` class, and this release wires both up.
+
+- `hcm_analyze` gains `analyze_bicycle_los` in its method enum and one line in its catalog. The tool surface itself is unchanged: three capability tools, as before.
+- `hcm_describe analyze_bicycle_los` serves the shipped fixture, the Chapter 15 widening example's current design (12 ft lane, 2 ft shoulder, 50 mi/h posted, pavement rated 3), whose published BLOS score is 5.90 at LOS F. Widening the shoulder to 6 ft, raising the limit to 55 mi/h and repaving to a 5 rating gives 3.58 at LOS D, and `tests/test_methods.py` drives both designs at the library's own tolerances.
+- `hcm_validate` runs a real dry run for this method, so twenty-four of the thirty-three now do. The library reaches the bicycle mode through a bare JSON function, which normally means there is no step between parse and compute, but the same nine inputs are also a `BicycleLOS` constructor that computes nothing, so the parse can be run there honestly. It checks that all nine fields are present and typed, not that they are in range.
+- The REST route `/analysis/hcm/analyze-bicycle-los` comes with it, as for every other method.
+
+Two things about this method are worth knowing before calling it, and both are in the tool's own description. `heavy_vehicle_pct` and `pct_on_highway_parking` are decimals, 0.05 for 5%, which is the opposite of the `phv` percent convention in the same chapter's motorized schema, and a percent passed as a percent drives the score far past LOS F without raising. And Equation 15-46 takes ln(speed_limit - 20), so at a posted limit of 20 mi/h or below the library returns a null `blos_score` while still reporting an `los` letter computed from the non-finite value. That defect is pinned rather than fixed in the library (guarding it would change what the web calculator and this server return, which is Rei's call), so the tool passes it through and says in its description that the null is the answer and the letter beside it is not.
+
+### Changed
+
+- Minimum `transportations-library` raised from 0.3.6 to 0.3.7, the first release exposing `analyze_bicycle_los` and `BicycleLOS` to Python. **Publish order: `transportations-library` 0.3.7 goes to PyPI before this release is deployed or published.** Until it does, a clean `uv sync --no-sources` install cannot resolve the floor.
 
 ### Fixed: `validation_validate_design_full` was a stub in every clean install
 
@@ -97,4 +112,4 @@ It defaults **off**, and that is deliberate. `mcp_server_fastapi.py` is the `ct`
 
 ### Known gaps
 
-The Chapter 15 bicycle mode (`BicycleLOS`) is implemented in the Rust library and has its own worked-example fixture, but it is not exported through the PyO3 bindings, so it has no tool here. Closing that gap is a change to `transportations-library`, not to this repository.
+The Chapter 15 bicycle mode (`BicycleLOS`) is implemented in the Rust library and has its own worked-example fixture, but it is not exported through the PyO3 bindings, so it has no tool here. Closing that gap is a change to `transportations-library`, not to this repository. (Closed in 0.3.1, against `transportations-library` 0.3.7.)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A FastAPI-based Model Context Protocol (MCP) server for Highway Capacity Manual 
 
 - Semantic search over HCM documentation
 - Complete HCM Chapter 15 (two-lane highway) and Chapter 12 (basic freeway) analysis
-- Full HCM chapter coverage, chapters 10 through 28, behind three capability tools (`hcm_analyze`, `hcm_describe`, `hcm_validate`) over 32 methods, each taking the library's own example-case JSON and each validated against its published example problem
+- Full HCM chapter coverage, chapters 10 through 28, behind three capability tools (`hcm_analyze`, `hcm_describe`, `hcm_validate`) over 33 methods, each taking the library's own example-case JSON and each validated against its published example problem
 - Input validation gateway against HCM/AASHTO constraints (via `transportations-validator`)
 - Full-corpus validation (300+ rules across HCM/AASHTO/MUTCD/HSM/ADA/...) with citations, terrain/context-gated rules, and clarification requests — runs in-process, no database
 - Knowledge-graph reasoning: abductive design repair (Two-Lane & Basic Freeway), defeasible code reconciliation, inverse design, and forward/backward chaining — every repair candidate re-executed through the verified library
@@ -284,13 +284,13 @@ A different equation family than Chapter 15 — the `lane width -> FFS -> capaci
 
 ### HCM Analysis Capabilities (full chapter coverage)
 
-Every HCM method the compute library implements, chapters 10 through 28, behind **three capability tools**. The method is an argument, not a tool: thirty-two near-identical schemas would cost every caller context and blunt tool selection, and the ten published tools above are already capability-shaped.
+Every HCM method the compute library implements, chapters 10 through 28, behind **three capability tools**. The method is an argument, not a tool: thirty-three near-identical schemas would cost every caller context and blunt tool selection, and the ten published tools above are already capability-shaped.
 
-- `hcm_analyze` — `{method, config}`. Runs one method. The tool description carries the method catalog, one compact line each, and `method` is an enum of the thirty-two ids.
+- `hcm_analyze` — `{method, config}`. Runs one method. The tool description carries the method catalog, one compact line each, and `method` is an enum of the thirty-three ids.
 - `hcm_describe` — `{method?}`. With a method: its input schema sketch, its result-field meanings and the example-problem fixture that validates it. Without one: the catalog, every method id with its chapter and a one-line summary. Call this first; it is how a caller learns a method's shape without reading the Rust bindings.
-- `hcm_validate` — `{method, config}`. Parses and checks a config **without running the analysis**, returning the library's own validation errors or ok. Iterating on a config costs a parse rather than a full analysis. Twenty-three of the thirty-two methods have a real validation step behind the constructor (serde deserialisation, constructor range checks, and for Chapter 15 the Exhibit 15-8 parameter ranges via `tl.validate_input`); the other nine are single JSON entry points in the library where parsing and computation are one call, and those say so in the response rather than running the analysis and calling it a validation.
+- `hcm_validate` — `{method, config}`. Parses and checks a config **without running the analysis**, returning the library's own validation errors or ok. Iterating on a config costs a parse rather than a full analysis. Twenty-four of the thirty-three methods have a real validation step behind the constructor (serde deserialisation, constructor range checks, and for Chapter 15 the Exhibit 15-8 parameter ranges via `tl.validate_input`); the other nine are single JSON entry points in the library where parsing and computation are one call, and those say so in the response rather than running the analysis and calling it a validation.
 
-The input is always the compute library's own example-case (fixture) JSON, passed as `config` — not a second flattened schema invented for the MCP layer. An example case from `transportations-library/tests/ExampleCases/hcm/` can be handed over unmodified. Requires `transportations-library>=0.3.6`.
+The input is always the compute library's own example-case (fixture) JSON, passed as `config` — not a second flattened schema invented for the MCP layer. An example case from `transportations-library/tests/ExampleCases/hcm/` can be handed over unmodified. Requires `transportations-library>=0.3.7`.
 
 | Chapter | `method` | What it computes |
 | --- | --- | --- |
@@ -300,6 +300,7 @@ The input is always the compute library's own example-case (fixture) JSON, passe
 | 12 | `analyze_basic_freeway` | Basic freeway and multilane segment |
 | 13 | `analyze_weaving` | Freeway weaving segment (HCM 7 and 7.1) |
 | 14 | `analyze_merge_diverge` | Freeway merge and diverge segment (HCM 7 and 7.1) |
+| 15 | `analyze_bicycle_los` | Two-lane and multilane highway segment, bicycle mode |
 | 15 | `analyze_two_lane_highway` | Two-lane highway facility |
 | 16 | `analyze_urban_facility` | Urban street facility |
 | 17 | `analyze_urban_reliability` | Urban street travel-time reliability |

--- a/function_registry.yaml
+++ b/function_registry.yaml
@@ -215,6 +215,7 @@ functions:
             analyze_basic_freeway (Ch.12): Basic freeway and multilane segment
             analyze_weaving (Ch.13): Freeway weaving segment
             analyze_merge_diverge (Ch.14): Freeway merge and diverge segment
+            analyze_bicycle_los (Ch.15): Two-lane and multilane highway segment, bicycle mode
             analyze_two_lane_highway (Ch.15): Two-lane highway facility
             analyze_urban_facility (Ch.16): Urban street facility
             analyze_urban_reliability (Ch.17): Urban street travel-time reliability
@@ -252,6 +253,7 @@ functions:
             - analyze_alternative_intersection
             - analyze_awsc
             - analyze_basic_freeway
+            - analyze_bicycle_los
             - analyze_bicycle_segment
             - analyze_composite_grade
             - analyze_displaced_left_turn

--- a/hcm_mcp_server/data/examples/analyze_bicycle_los.json
+++ b/hcm_mcp_server/data/examples/analyze_bicycle_los.json
@@ -1,0 +1,12 @@
+{
+    "_source": "HCM 7th Edition, Chapter 15 Section 4 widening example (transportations-library tests/ExampleCases/hcm/TwoLaneHighways/bicycle_widening.json, 'current' design): 12 ft lane, 2 ft shoulder, 50 mi/h posted, pavement rated 3, published BLOS score 5.90 at LOS F. The same segment after widening the shoulder to 6 ft, raising the limit to 55 mi/h and repaving to a 5 rating scores 3.58 at LOS D.",
+    "lane_width": 12.0,
+    "shoulder_width": 2.0,
+    "speed_limit": 50.0,
+    "num_lanes": 1,
+    "pavement_condition": 3.0,
+    "hourly_volume": 500.0,
+    "phf": 0.90,
+    "heavy_vehicle_pct": 0.05,
+    "pct_on_highway_parking": 0.0
+}

--- a/hcm_mcp_server/functions/methods.py
+++ b/hcm_mcp_server/functions/methods.py
@@ -461,6 +461,27 @@ def analyze_two_lane_highway_function(data: Dict[str, Any]) -> Dict[str, Any]:
     return _dispatch(_run_two_lane_highway, data)
 
 
+@_guarded
+def _run_bicycle_los(config: Dict[str, Any]) -> Dict[str, Any]:
+    return {"success": True, "results": json.loads(tl.analyze_bicycle_los(json.dumps(config)))}
+
+
+def analyze_bicycle_los_function(data: Dict[str, Any]) -> Dict[str, Any]:
+    """HCM Chapter 15, Section 4 bicycle mode on a two-lane or multilane highway segment.
+
+    The bicycle method's input set is not the motorized method's, which is why this is a separate method rather than a mode argument on ``analyze_two_lane_highway``: pavement rating and on-highway parking govern the score, and segment length does not enter it at all.
+
+    Input is the bicycle-LOS fixture schema: ``lane_width`` and ``shoulder_width`` in feet, ``speed_limit`` in mi/h, ``num_lanes`` (directional through lanes, 1 for a two-lane highway), ``pavement_condition`` on the FHWA 5-point scale where 1 is very poor and 5 very good, ``hourly_volume`` in veh/h, ``phf``, and ``heavy_vehicle_pct`` and ``pct_on_highway_parking``. All nine are required; none of them defaults. Worked example: ``analyze_bicycle_los`` ships the HCM two-lane highway widening example, a 12 ft lane with a 2 ft shoulder at a posted 50 mi/h whose published BLOS score is 5.90 at LOS F, and 3.58 at LOS D after the project widens the shoulder to 6 ft, raises the limit to 55 mi/h and repaves.
+
+    ``heavy_vehicle_pct`` and ``pct_on_highway_parking`` are DECIMALS here, 0.05 for 5%, which is the opposite of the ``phv`` percent convention in the same chapter's motorized schema. A percent passed as a percent does not raise; it drives the score far past the LOS F threshold.
+
+    ``flow_rate_outside_lane`` is the Step 2 directional flow in the outside lane in veh/h, ``effective_width`` the Step 3 effective width of that lane in feet (which shoulder width moves in steps, at 4 ft and 8 ft, rather than continuously), ``effective_speed_factor`` the Step 4 term from the posted limit, and ``blos_score`` the Equation 15-47 score whose Exhibit 15-7 letter is ``los``. The score runs the opposite way to a grade: lower is better, and a project succeeds by reducing it.
+
+    Equation 15-46 takes ln(speed_limit - 20), so a posted limit of 20 mi/h or below has no defined effective speed factor. The library returns ``effective_speed_factor`` and ``blos_score`` as null there while still reporting an ``los`` letter from the raw value, and that letter is meaningless. Treat a null score as the answer, not the letter beside it.
+    """
+    return _dispatch(_run_bicycle_los, data)
+
+
 # ── Chapters 16-18: urban streets ────────────────────────────────────────────
 
 _URBAN_FACILITY = ["los", "poorest_segment_los", "travel_speed_mph", "base_free_flow_speed_mph",
@@ -1011,6 +1032,8 @@ METHODS: Dict[str, Dict[str, Any]] = {
                               "title": "Freeway merge and diverge segment", "editions": ["7", "7.1"]},
     "analyze_two_lane_highway": {"chapter": 15, "library": "TwoLaneHighways", "function": analyze_two_lane_highway_function,
                                  "title": "Two-lane highway facility"},
+    "analyze_bicycle_los": {"chapter": 15, "library": "analyze_bicycle_los", "function": analyze_bicycle_los_function,
+                            "title": "Two-lane and multilane highway segment, bicycle mode"},
     "analyze_urban_facility": {"chapter": 16, "library": "UrbanFacility", "function": analyze_urban_facility_function,
                                "title": "Urban street facility"},
     "analyze_urban_reliability": {"chapter": 17, "library": "UrbanReliability", "function": analyze_urban_reliability_function,
@@ -1069,7 +1092,10 @@ METHODS: Dict[str, Dict[str, Any]] = {
 # range checks) and raises with the library's own message, without running a
 # single equation. Methods reached through a bare JSON function have no such
 # split -- validation happens inside the analysis -- and those say so rather
-# than quietly running the analysis and calling it a validation.
+# than quietly running the analysis and calling it a validation. The one
+# exception is analyze_bicycle_los, whose bare JSON function is shadowed by a
+# BicycleLOS class holding the same input set and computing nothing, so the
+# parse can be run there.
 
 
 def _json_class_validator(cls_name: str) -> Callable[[Dict[str, Any]], None]:
@@ -1115,6 +1141,21 @@ def _validate_two_lane_highway(config: Dict[str, Any]) -> None:
         raise ValueError("; ".join(errors))
 
 
+_BICYCLE_LOS_KEYS = ("lane_width", "shoulder_width", "speed_limit", "num_lanes", "pavement_condition",
+                     "hourly_volume", "phf", "heavy_vehicle_pct", "pct_on_highway_parking")
+
+
+def _validate_bicycle_los(config: Dict[str, Any]) -> None:
+    """The bicycle mode reaches the engine through a bare JSON function, but the same input set is also a ``BicycleLOS`` constructor that computes nothing, so a dry run here is a real parse rather than the analysis under another name. The missing-field check is spelled out because serde names only the first field it misses, and a config short three fields is worth learning about in one round trip."""
+    missing = [k for k in _BICYCLE_LOS_KEYS if config.get(k) is None]
+    if missing:
+        raise ValueError(
+            f"missing required field(s) {', '.join(repr(k) for k in missing)}: BicycleLOS has no defaults, "
+            "every one of the nine inputs enters Equation 15-47"
+        )
+    tl.BicycleLOS(*(config[k] for k in _BICYCLE_LOS_KEYS))
+
+
 def _validate_ramp_service_volumes(config: Dict[str, Any]) -> None:
     _ramp_segment(config["segment"])
     if (config.get("ramp_fraction") is None) == (config.get("fixed_freeway_vf") is None):
@@ -1145,6 +1186,7 @@ _VALIDATORS: Dict[str, Any] = {
     "analyze_weaving": (_kwargs_validator(_weaving_segment), "the WeavingSegment keyword constructor's range and enum checks"),
     "analyze_merge_diverge": (_kwargs_validator(_ramp_segment), "the RampSegment keyword constructor's range and enum checks"),
     "analyze_two_lane_highway": (_validate_two_lane_highway, "the Segment/SubSegment constructors plus tl.validate_input's Exhibit 15-8 parameter ranges"),
+    "analyze_bicycle_los": (_validate_bicycle_los, "the nine required BicycleLOS inputs and their types, through the constructor (no range check: Equation 15-46 is undefined at a posted speed limit of 20 mi/h or below and the library does not refuse it)"),
     "analyze_urban_facility": (_json_class_validator("UrbanFacility"), "serde deserialisation of the urban facility config"),
     "analyze_urban_reliability": (_json_class_validator("UrbanReliability"), "serde deserialisation of the urban reliability config"),
     "analyze_urban_segment": (_json_class_validator("UrbanSegment"), "serde deserialisation of the urban segment config"),
@@ -1219,8 +1261,8 @@ def _method_row(name: str, entry: Dict[str, Any]) -> Dict[str, Any]:
 # ── The three capability tools ───────────────────────────────────────────────
 # The MCP surface is capability-shaped, matching the ten tools of the published
 # surface: one tool to run a method, one to discover it, one to dry-run a config.
-# The 32 per-method functions above stay as the implementation and keep their
-# REST routes; they are not advertised as separate tools, because 32 near-
+# The 33 per-method functions above stay as the implementation and keep their
+# REST routes; they are not advertised as separate tools, because 33 near-
 # identical schemas cost every caller context and blunt tool selection.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hcm-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 description = "A FastAPI-based Model Context Protocol (MCP) server for Highway Capacity Manual (HCM) analysis and transportation engineering calculations."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -55,15 +55,18 @@ dependencies = [
     # The reasoning layer (repair/reconcile/inverse/chaining + BasicFreeway), the
     # Chapter 12 tools, and validate_design_full need:
     #   - transportations-validator >=0.3.0 (seed-backed engine + reasoning modules + coverage/abstention on semantic results)
-    #   - transportations-library >=0.3.6. The floor moved from 0.2.0 with the
+    #   - transportations-library >=0.3.7. The floor moved from 0.2.0 with the
     #     per-method hcm_analyze_* surface: 0.3.6 is the first release exposing
     #     analyze_mixed_flow / analyze_composite_grade / analyze_twsc_pedestrian
     #     and the ManagedLaneFacility, PlanningFacility, AlternativeIntersection
     #     and DisplacedLeftTurn classes to Python. On 0.3.0 those names are
     #     simply absent, so their tools would register as unavailable stubs
-    #     rather than fail loudly at import.
+    #     rather than fail loudly at import. 0.3.7 adds analyze_bicycle_los and
+    #     BicycleLOS, which the Chapter 15 bicycle-mode method needs. PUBLISH
+    #     ORDER: library 0.3.7 reaches PyPI before this release is deployed or
+    #     published, or a --no-sources install cannot resolve this floor.
     "transportations-validator>=0.3.0",
-    "transportations-library>=0.3.6",
+    "transportations-library>=0.3.7",
 ]
 
 [dependency-groups]

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,6 +1,6 @@
 """The full HCM method coverage, every method driven through the ``hcm_analyze`` capability tool against its example-problem fixture.
 
-The MCP surface is capability-shaped: three tools (``hcm_analyze``, ``hcm_describe``, ``hcm_validate``) over thirty-two methods. Every analysis below therefore goes through ``hcm_analyze`` with a ``method`` argument, which is the path a real caller takes, rather than reaching into the per-method implementation function. Each call is made the way ``/tools/call`` makes it — ``registry.get_function(name)(arguments)`` — so a failure here means the analysis is wrong, the dispatch is wrong, or the registry wiring is, and the three are not confused.
+The MCP surface is capability-shaped: three tools (``hcm_analyze``, ``hcm_describe``, ``hcm_validate``) over thirty-three methods. Every analysis below therefore goes through ``hcm_analyze`` with a ``method`` argument, which is the path a real caller takes, rather than reaching into the per-method implementation function. Each call is made the way ``/tools/call`` makes it — ``registry.get_function(name)(arguments)`` — so a failure here means the analysis is wrong, the dispatch is wrong, or the registry wiring is, and the three are not confused.
 
 Every expected value and tolerance below is cribbed from the compute library's own test suite for that example problem (``transportations-library/tests/test_chapter*_integration.py`` for the Python-tested chapters, ``tests/chapter*_integration.rs`` for the ones the Rust side pins). Nothing here is an invented tolerance: where the library asserts +-0.5 mi/h, so does this file, and where the library documents a computed-versus-published gap the value asserted is the library's computed one with the published one in the comment. The published-value provenance lives in the fixtures' own ``_source`` lines.
 """
@@ -302,6 +302,64 @@ class TestTwoLaneHighway:
         assert round(r["facility_follower_density"], 3) == 10.092
         assert r["facility_posted_speed_limit"] == pytest.approx(50.0)
         assert result["level_of_service"] == "D"
+
+
+class TestBicycleLOS:
+    """The Chapter 15 Section 4 widening example, both designs.
+
+    Expected values and tolerances are the library's own (``tests/test_bicycle_los_integration.py``, itself mirroring the Rust ``bicycle_los_widening_example_test``). The shipped fixture is the current design; the proposed one is the same segment with the three fields the project changes, which is what makes the F to D move visible from here rather than only inside the library.
+    """
+
+    @pytest.fixture(scope="class")
+    def current(self, registry):
+        return run_example(registry, "analyze_bicycle_los")["results"]
+
+    @pytest.fixture(scope="class")
+    def proposed(self, registry):
+        config = dict(methods._example("analyze_bicycle_los"),
+                      shoulder_width=6.0, speed_limit=55.0, pavement_condition=5.0)
+        result = analyze(registry, "analyze_bicycle_los", config)
+        assert result["success"] is True, result.get("error")
+        return result["results"]
+
+    def test_step_2_flow_rate(self, current, proposed):
+        # Only the cross section and the limit change, so vOL = 500 / (0.90 x 1) either way.
+        assert current["flow_rate_outside_lane"] == pytest.approx(555.6, abs=0.1)
+        assert proposed["flow_rate_outside_lane"] == pytest.approx(555.6, abs=0.1)
+
+    def test_steps_3_and_4(self, current, proposed):
+        # The 2 ft shoulder takes Equation 15-43 and the 6 ft shoulder Equation
+        # 15-42, which is why We moves 10 ft for 4 ft of added shoulder.
+        assert current["effective_width"] == pytest.approx(14.0, abs=0.01)
+        assert proposed["effective_width"] == pytest.approx(24.0, abs=0.01)
+        assert current["effective_speed_factor"] == pytest.approx(4.62, abs=0.01)
+        assert proposed["effective_speed_factor"] == pytest.approx(4.79, abs=0.01)
+
+    def test_published_values(self, current, proposed):
+        # Tolerance +-0.01 because the book rounds its intermediates to two
+        # decimals; the LOS letters are exact.
+        assert current["blos_score"] == pytest.approx(5.90, abs=0.01)
+        assert proposed["blos_score"] == pytest.approx(3.58, abs=0.01)
+        assert (current["los"], proposed["los"]) == ("F", "D")
+        # A lower score is a better LOS, so the project buys two letters.
+        assert proposed["blos_score"] < current["blos_score"]
+
+    def test_a_posted_limit_at_the_singularity_returns_a_null_score(self, registry):
+        """Equation 15-46 takes ln(Spl - 20), and the library returns a null score with an unguarded LOS letter at or below 20 mi/h rather than refusing. The tool passes that through, so pin what a caller actually sees: the null is the answer and the letter beside it is not."""
+        config = dict(methods._example("analyze_bicycle_los"), speed_limit=20.0)
+        r = analyze(registry, "analyze_bicycle_los", config)
+        assert r["success"] is True
+        assert r["results"]["blos_score"] is None
+        assert r["results"]["effective_speed_factor"] is None
+
+    def test_a_missing_input_is_refused_rather_than_defaulted(self, registry):
+        """None of the nine inputs has an HCM-stated default. A dropped pavement rating moves the score by more than a whole letter, so it has to fail in both capabilities, not just one."""
+        config = dict(methods._example("analyze_bicycle_los"))
+        del config["pavement_condition"]
+        assert analyze(registry, "analyze_bicycle_los", config)["success"] is False
+        validated = call(registry, "hcm_validate", method="analyze_bicycle_los", config=config)
+        assert validated["valid"] is False
+        assert "pavement_condition" in validated["error"]
 
 
 # ── Chapters 16-18: urban streets ────────────────────────────────────────────
@@ -917,7 +975,7 @@ class TestMethodTableIntegrity:
             json.loads(path.read_text())
 
     def test_the_mcp_surface_is_three_capability_tools(self, registry):
-        """One tool per method would put thirty-two near-identical schemas in every caller's context. The method is an argument."""
+        """One tool per method would put thirty-three near-identical schemas in every caller's context. The method is an argument."""
         names = {n for n in registry.get_all_functions() if n.startswith("hcm_")}
         assert names == {"hcm_analyze", "hcm_describe", "hcm_validate"}
 

--- a/uv.lock
+++ b/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "hcm-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },
@@ -555,7 +555,7 @@ requires-dist = [
     { name = "simpleeval", specifier = ">=1.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "supabase", specifier = "==2.18.0" },
-    { name = "transportations-library", specifier = ">=0.3.6" },
+    { name = "transportations-library", editable = "../transportations-library" },
     { name = "transportations-validator", specifier = ">=0.3.0" },
 ]
 
@@ -2396,14 +2396,17 @@ wheels = [
 
 [[package]]
 name = "transportations-library"
-version = "0.3.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a3/8d/e987a0e3790a215892ead1c836c8a52038af7579639bac916bbaf4e9ad97/transportations_library-0.3.6.tar.gz", hash = "sha256:2dc58ae4d3b0a310c79d36870133416597b829633ad7cf48c588226a9f022844", size = 869438, upload-time = "2026-08-18T02:46:48.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/6d/cb3e0226ddd3a820b100f8e8ae86cd62dee8677e2f3a34e47b09d73cf9dd/transportations_library-0.3.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0a6b9d7d7fed61ba93f68694f0db247b474810b2035ec9264fa0b8c4a389c03", size = 1087435, upload-time = "2026-08-18T02:46:43.452Z" },
-    { url = "https://files.pythonhosted.org/packages/97/a6/3c5a66891243f21ed630f4a18108d8b7e2ebf74b4735ea2c922a01f40099/transportations_library-0.3.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7d94e6275dfd50b7b8b24ba474392dc2c7f17e3cf42fcafe65dfe357e03a506", size = 1167826, upload-time = "2026-08-18T02:46:45.109Z" },
-    { url = "https://files.pythonhosted.org/packages/40/87/d42e0858f2e0377cdd48c0ff5b19e7d42c4bd63198ae83504bd1c1d53667/transportations_library-0.3.6-cp312-cp312-win_amd64.whl", hash = "sha256:486487a8cbc221307b4298c5a6420e7c02152cb054f4e5c3c9f9649c7dd9f532", size = 1082043, upload-time = "2026-08-18T02:46:46.752Z" },
+source = { editable = "../transportations-library" }
+
+[package.metadata]
+requires-dist = [
+    { name = "pymupdf", marker = "extra == 'pdf'", specifier = ">=1.26.6" },
+    { name = "pymupdf-layout", marker = "extra == 'pdf'", specifier = ">=1.26.6" },
+    { name = "pymupdf4llm", marker = "extra == 'pdf'", specifier = ">=0.0.17" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=6.0" },
+    { name = "pytest-cov", marker = "extra == 'test'" },
 ]
+provides-extras = ["pdf", "test"]
 
 [[package]]
 name = "transportations-validator"


### PR DESCRIPTION
Closes the last method gap: analyze_bicycle_los joins the enum and catalog (the tool surface stays exactly three capability tools — frozen guard verified green including the additions assertion). hcm_describe ships the widening example (current 5.90/F, proposed 3.58/D, both reproduced through the dispatch at library tolerances); hcm_validate gets a REAL dry run through the exported class constructor (24 of 33 methods now have one), with its `checked` string honest about covering presence/type but not ranges, and naming the ≤20 mi/h undefined domain the library deliberately does not refuse — the tool description says the null score is the answer there. REST route auto-generated from the METHODS table. MCP 0.3.0 → 0.3.1, library floor → 0.3.7.

**⚠️ CI on this branch fails by design until transportations-library 0.3.7 is on PyPI** — uv.lock was deliberately not refreshed (regenerating it either bakes in a local path or fails against the index). Merge order: library PR first, publish 0.3.7, then a lock refresh lands here and CI goes green before merge.

Gates (local, against the library branch via a non-committed path override — pyproject diff verified clean of scratchpad paths): 171 passed / 0 failed / 0 skipped (+5), ruff zero findings, frozen guard green, loud-import tests green, registry validator clean. One judgment call flagged: the CHANGELOG's Unreleased heading became 0.3.1, folding the simpleeval fix in — one line to change if you want it separate.